### PR TITLE
Allow version 7 for Guzzle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require": {
         "php": ">=5.6",
-        "guzzlehttp/guzzle": "^6.3.0"
+        "guzzlehttp/guzzle": "^6.3.0|^7.0"
     },
     "license": "MIT"
 }


### PR DESCRIPTION
Guzzle 6 causes deprecation warnings on newer PHP versions. Guzzle 7 works fine for the purposes of this package, so I've included it in the composer version constraint.